### PR TITLE
feat(STONEINTG-1230): add trusted tasks bundles for intg service

### DIFF
--- a/default/policy.yaml
+++ b/default/policy.yaml
@@ -35,6 +35,7 @@ sources:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
     config:
       include:
         - '@slsa3'

--- a/everything/policy.yaml
+++ b/everything/policy.yaml
@@ -37,6 +37,7 @@ sources:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
     config:
       include:
         - '*'

--- a/minimal/policy.yaml
+++ b/minimal/policy.yaml
@@ -37,6 +37,7 @@ sources:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
     config:
       include:
         - '@minimal'

--- a/redhat-no-hermetic/policy.yaml
+++ b/redhat-no-hermetic/policy.yaml
@@ -35,6 +35,7 @@ sources:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
     config:
       include:
         - '@redhat'

--- a/redhat-rpms/policy.yaml
+++ b/redhat-rpms/policy.yaml
@@ -35,6 +35,7 @@ sources:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
       - oci::quay.io/enterprise-contract/rpmbuild-data-acceptable-bundles:latest
     config:
       include:

--- a/redhat/policy.yaml
+++ b/redhat/policy.yaml
@@ -35,6 +35,7 @@ sources:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
     config:
       include:
         - '@redhat'

--- a/slsa3/policy.yaml
+++ b/slsa3/policy.yaml
@@ -35,6 +35,7 @@ sources:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
     config:
       include:
         - '@minimal'

--- a/src/policy-konflux.yaml.tmpl
+++ b/src/policy-konflux.yaml.tmpl
@@ -40,6 +40,7 @@ sources:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
       {{- range index . "extra-data" }}
       - {{ . }}
       {{- end }}


### PR DESCRIPTION
* add quay.io/konflux-ci/integration-service-catalog /data-acceptable-bundles:latest to policies

Signed-off-by: Hongwei Liu <hongliu@redhat.com>